### PR TITLE
Added artifact archival and circleci status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Gravity Assist
 
 </h3>
+
+<img src="https://circleci.com/gh/adityai/gravity-assist.svg?style=shield&circle-token=:circle-token" />
+
 <p align="center">
 A <a href="https://en.wikipedia.org/wiki/Gravity_assist">gravitational assist</a> simulator that simulates the motion of objects as they enter and exit gravitational fields. The program is written using C++ and OpenGL and uses 'real physics' applying <a href="https://en.wikipedia.org/wiki/Kepler's_laws_of_planetary_motion">Kepler's Laws</a> and <a href="https://en.wikipedia.org/wiki/Newton's_law_of_universal_gravitation">Newtonian Gravitation</a> to simulate the gravitational slingshots.<br><br>
 Trello Board can be found <a href="https://trello.com/b/IzK134h0/gravity-assist-general-board">here</a>. 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <h3 align="center">
-Gravity Assist
-
-</h3>
-
+Gravity Assist<br><br>
 <img src="https://circleci.com/gh/adityai/gravity-assist.svg?style=shield&circle-token=:circle-token" />
+</h3>
 
 <p align="center">
 A <a href="https://en.wikipedia.org/wiki/Gravity_assist">gravitational assist</a> simulator that simulates the motion of objects as they enter and exit gravitational fields. The program is written using C++ and OpenGL and uses 'real physics' applying <a href="https://en.wikipedia.org/wiki/Kepler's_laws_of_planetary_motion">Kepler's Laws</a> and <a href="https://en.wikipedia.org/wiki/Newton's_law_of_universal_gravitation">Newtonian Gravitation</a> to simulate the gravitational slingshots.<br><br>

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ dependencies:
   post:
    - ls -ltr
    - g++ orbit.cpp -lGL -lGLU -lGLEW -lglut -o orbit
+   - cp orbit $CIRCLE_ARTIFACTS/
       
 test:
   override:


### PR DESCRIPTION
The circleci build now archives the orbit executable. 

Example: https://circleci.com/gh/adityai/gravity-assist/11#artifacts/containers/0

Added: <img src="https://circleci.com/gh/adityai/gravity-assist.svg?style=shield&circle-token=:circle-token" /> to readme. This places a build status badge on the readme.

Replace it with your url when you merge to master: I am guessing it will be <img src="https://circleci.com/gh/AlbertFaust/gravity-assist.svg?style=shield&circle-token=:circle-token" />

